### PR TITLE
Update image extraction to handle GitHub's new rendering

### DIFF
--- a/hub-purge.sh
+++ b/hub-purge.sh
@@ -15,9 +15,10 @@ for url in "$@"; do
     # Fetch README page
     echo "Fetching: $url"
     curl -sL "$url" \
-    | grep -oE '<img src="https?://camo.githubusercontent.com/[^"]+' \
-    | sed -e 's/<img src="//' \
-    | while read url; do
+    | sed -n '/<script type="application\/json" data-target="react-partial.embeddedData">/,/<\/script>/p' \
+    | sed 's/\\u003e/>/g; s/\\u002F/\//g; s/\\u0022/"/g; s/\\//g' \
+    | grep -oE 'https?://camo.githubusercontent.com/[^"]+' \
+    | while read -r url; do
 
         # Purge resources
         echo "Purging: $url"


### PR DESCRIPTION
Remove escaping backslashes from extracted URLs to ensure correct URI formatting before purging. This change addresses the issue where extracted image URLs from GitHub's JSON data contained an unintended trailing backslash.